### PR TITLE
feat: add device timezone offset to Android log timestamps

### DIFF
--- a/android/src/main/java/com/mattermost/turbolog/TurboLog.kt
+++ b/android/src/main/java/com/mattermost/turbolog/TurboLog.kt
@@ -81,7 +81,7 @@ class TurboLog {
       val encoder = PatternLayoutEncoder()
       encoder.context = loggerContext
       encoder.charset = StandardCharsets.UTF_8
-      encoder.pattern = "%d{yyyy/MM/dd HH:mm:ss.SSS} %-5level %msg%n"
+      encoder.pattern = "%d{yyyy/MM/dd HH:mm:ss.SSS Z} %-5level %msg%n"
       encoder.start()
 
       rollingFileAppender.encoder = encoder

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1749,7 +1749,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   TurboLogIOSNative:
-    :commit: 44fa9abe32a74ce6206d6237c639e6382495d210
+    :commit: 4021fac1af04b31df8e19370267595134a0dbb2e
     :git: https://github.com/mattermost/react-native-turbo-log-ios-native.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
## Summary

Exported logs written by this package (used for "Report a Problem" log exports and captured console output) previously wrote local-device-time timestamps **without any timezone indicator**, relying on the JVM default timezone which is not recorded in the log line itself. This makes it hard to correlate log timestamps across devices/timezones when triaging exported logs or Sentry breadcrumbs.

This PR appends the device's numeric timezone offset to the Android Logback encoder pattern.

## Change

`android/src/main/java/com/mattermost/turbolog/TurboLog.kt`

```diff
- encoder.pattern = "%d{yyyy/MM/dd HH:mm:ss.SSS} %-5level %msg%n"
+ encoder.pattern = "%d{yyyy/MM/dd HH:mm:ss.SSS Z} %-5level %msg%n"
```

Logback's `%d{...}` uses `SimpleDateFormat`, where `Z` emits the numeric timezone offset. Log lines now read e.g.:

```
2026/07/06 14:03:22.451 +0200 DEBUG ...
```

instead of:

```
2026/07/06 14:03:22.451 DEBUG ...
```

`Z` (numeric offset) was chosen over `zzz` (zone abbreviation) since a stable numeric offset is unambiguous for cross-device correlation.

## iOS (follow-up needed)

iOS timestamps are formatted in the separate `react-native-turbo-log-ios-native` (`TurboLogIOSNative`) pod, not in this repository — this package only re-exports its `write` call. The equivalent timezone-offset change needs a companion PR in that repo.

## Downstream

`mattermost/mobile` consumes this as `@mattermost/react-native-turbo-log` (currently pinned at `0.6.0`) and will need a version bump once this is released.

Jira: [MM-69702](https://mattermost.atlassian.net/browse/MM-69702)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kwbwn9Z7xGkva7rbojmSaV)_